### PR TITLE
fix: exclude unreviewed cards from FSRS histograms

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -296,9 +296,10 @@ fn render_fsrs_histogram(
             Theme::bullet(),
             Theme::muted_span("Average"),
             Theme::bullet(),
-            Theme::label_span(histogram_stats.mean()
-                .map_or_else(|| "NA - No cards reviewed".to_string(),
-                             |v| format!("{}%", (v * 100.0).round()))),
+            Theme::label_span(histogram_stats.mean().map_or_else(
+                || "NA - No cards reviewed".to_string(),
+                |v| format!("{}%", (v * 100.0).round()),
+            )),
         ]),
         Line::from(Theme::muted_span(description)),
     ])

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -224,7 +224,11 @@ mod tests {
         histogram.update(0.6);
 
         let mean = histogram.mean().unwrap();
-        assert!((mean - 0.4).abs() < 0.001, "Expected mean ~0.4, got {}", mean);
+        assert!(
+            (mean - 0.4).abs() < 0.001,
+            "Expected mean ~0.4, got {}",
+            mean
+        );
     }
 
     #[test]
@@ -260,6 +264,10 @@ mod tests {
         assert_eq!(total_count, 1);
         assert!(stats.difficulty_histogram.mean().is_some());
         let mean = stats.difficulty_histogram.mean().unwrap();
-        assert!((mean - 0.75).abs() < 0.001, "Expected mean ~0.75, got {}", mean);
+        assert!(
+            (mean - 0.75).abs() < 0.001,
+            "Expected mean ~0.75, got {}",
+            mean
+        );
     }
 }


### PR DESCRIPTION
## Summary
Fixes #6

This PR ensures that FSRS histograms only include data from cards that have actually been reviewed, preventing misleading statistics on fresh installs.

## Changes
- Updated `Histogram::mean()` to return `Option<f64>` instead of `f64` to safely handle empty histograms
- Added guard to only update difficulty histogram when `last_reviewed_at` is present
- Updated UI to display "NA - No cards reviewed" when histogram data is not available
- Added 4 new test cases for histogram mean calculation and difficulty tracking behavior
- Fixed existing test to align with new behavior

## Test plan
- [x] All existing tests pass
- [x] New tests verify histogram mean returns None when empty
- [x] New tests verify difficulty histogram is not updated for unreviewed cards
- [x] New tests verify difficulty histogram is updated correctly for reviewed cards