### PR TITLE
feat: utilize ansci defined colors rather than custom colors for TUI theme

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -118,19 +118,19 @@ fn draw_dashboard(frame: &mut Frame<'_>, stats: &CardStats) {
 fn collection_panel(stats: &CardStats) -> Paragraph<'static> {
     let lines = vec![
         Line::from(vec![
-            Theme::muted_span("Tracked cards"),
+            Theme::span("Tracked cards"),
             Theme::bullet(),
             Theme::label_span(format!("{}", stats.num_cards)),
         ]),
         Line::from(vec![
-            Theme::muted_span("New"),
+            Theme::span("New"),
             Theme::bullet(),
             Theme::label_span(format!(
                 "{}",
                 *stats.card_lifecycles.get(&CardLifeCycle::New).unwrap_or(&0)
             )),
             Theme::bullet(),
-            Theme::muted_span("Young"),
+            Theme::span("Young"),
             Theme::bullet(),
             Theme::label_span(format!(
                 "{}",
@@ -140,7 +140,7 @@ fn collection_panel(stats: &CardStats) -> Paragraph<'static> {
                     .unwrap_or(&0)
             )),
             Theme::bullet(),
-            Theme::muted_span("Mature"),
+            Theme::span("Mature"),
             Theme::bullet(),
             Theme::label_span(format!(
                 "{}",
@@ -151,12 +151,12 @@ fn collection_panel(stats: &CardStats) -> Paragraph<'static> {
             )),
         ]),
         Line::from(vec![
-            Theme::muted_span("Files in Collection"),
+            Theme::span("Files in Collection"),
             Theme::bullet(),
             Theme::label_span(format!("{}", stats.file_paths.len())),
         ]),
         Line::from(vec![
-            Theme::muted_span("Total Cards Indexed in DB"),
+            Theme::span("Total Cards Indexed in DB"),
             Theme::bullet(),
             Theme::label_span(format!("{}", stats.total_cards_in_db)),
         ]),
@@ -181,21 +181,21 @@ fn due_panel(stats: &CardStats) -> Paragraph<'static> {
     let lines = vec![
         Line::from(vec![Span::styled("Focus", emphasis)]),
         Line::from(vec![
-            Theme::muted_span("Due load"),
+            Theme::span("Due load"),
             Theme::bullet(),
             Theme::label_span(format!("{:.0}%", load_factor * 100.0)),
             Theme::bullet(),
-            Theme::muted_span("Due now"),
+            Theme::span("Due now"),
             Theme::bullet(),
             Theme::label_span(format!("{}", stats.due_cards)),
-            Span::raw("  "),
+            Theme::span("  "),
         ]),
         Line::from(vec![
-            Theme::muted_span("Next 7 days"),
+            Theme::span("Next 7 days"),
             Theme::bullet(),
             Theme::label_span(format!("{}", upcoming_week_total)),
             Theme::bullet(),
-            Theme::muted_span("Next 30 days"),
+            Theme::span("Next 30 days"),
             Theme::bullet(),
             Theme::label_span(format!("{}", stats.upcoming_month)),
         ]),
@@ -206,7 +206,7 @@ fn due_panel(stats: &CardStats) -> Paragraph<'static> {
 fn render_upcoming_histogram(frame: &mut Frame<'_>, area: Rect, stats: &CardStats) {
     let block = Theme::panel_with_line(Theme::title_line("Next 7 days histogram"));
     if stats.upcoming_week.is_empty() {
-        let empty = Paragraph::new(vec![Line::from(vec![Theme::muted_span(
+        let empty = Paragraph::new(vec![Line::from(vec![Theme::span(
             "You're clear for the next 7 days.",
         )])])
         .block(block);
@@ -239,7 +239,7 @@ fn render_upcoming_histogram(frame: &mut Frame<'_>, area: Rect, stats: &CardStat
             Bar::default()
                 .value(*count as u64)
                 .text_value(count.to_string())
-                .label(Line::from(vec![Theme::muted_span(label)]))
+                .label(Line::from(vec![Theme::span(label)]))
                 .style(Theme::label())
         })
         .collect();
@@ -286,16 +286,15 @@ fn render_fsrs_histogram(
         Line::from(vec![
             Span::styled(format!("Card {}:", title), Theme::emphasis()),
             Theme::bullet(),
-            Theme::muted_span("Average"),
+            Theme::span("Average"),
             Theme::bullet(),
             Theme::label_span(histogram_stats.mean().map_or_else(
                 || "NA - No cards reviewed".to_string(),
                 |v| format!("{}%", (v * 100.0).round()),
             )),
         ]),
-        Line::from(Theme::muted_span(description)),
-    ])
-    .style(Theme::body());
+        Line::from(Theme::span(description)),
+    ]);
     frame.render_widget(difficulty_header, section_chunks[0]);
     let step_size = 100 / histogram_stats.bins.len().max(1);
     let bars: Vec<Bar> = histogram_stats
@@ -308,7 +307,7 @@ fn render_fsrs_histogram(
             Bar::default()
                 .value(*count as u64)
                 .text_value(count.to_string())
-                .label(Line::from(vec![Theme::muted_span(label)]))
+                .label(Line::from(vec![Theme::span(label)]))
                 .style(Theme::label())
         })
         .collect();
@@ -339,7 +338,7 @@ fn render_fsrs_histogram(
 fn render_fsrs_panel(frame: &mut Frame<'_>, area: Rect, stats: &CardStats) {
     let block = Theme::panel_with_line(Theme::title_line("FSRS Memory Health"));
     if stats.upcoming_week.is_empty() {
-        let empty = Paragraph::new(vec![Line::from(vec![Theme::muted_span(
+        let empty = Paragraph::new(vec![Line::from(vec![Theme::span(
             "No FSRS statistics to display",
         )])])
         .block(block);

--- a/src/create.rs
+++ b/src/create.rs
@@ -135,24 +135,24 @@ async fn capture_cards(db: &DB, card_path: &Path) -> Result<()> {
 
                 let mut help_lines = vec![Line::from(vec![
                     Theme::key_chip("Ctrl+B"),
-                    Span::styled(" basic", Theme::muted()),
+                    Theme::span(" basic"),
                     Theme::bullet(),
                     Theme::key_chip("Ctrl+K"),
-                    Span::styled(" cloze", Theme::muted()),
+                    Theme::span(" cloze"),
                     Theme::bullet(),
                     Theme::key_chip("Ctrl+S"),
-                    Span::styled(" save", Theme::muted()),
+                    Theme::span(" save"),
                     Theme::bullet(),
                     Theme::key_chip("Esc"),
-                    Span::styled(" / ", Theme::muted()),
+                    Theme::span(" / "),
                     Theme::key_chip("Ctrl+C"),
-                    Span::styled(" exit", Theme::muted()),
+                    Theme::span(" exit"),
                 ])];
                 help_lines.push(Line::from(vec![
-                    Span::styled("Cards in collection:", Theme::muted()),
+                    Theme::span("Cards in collection:"),
                     Theme::label_span(format!(" {}", num_cards_in_collection)),
                     Theme::bullet(),
-                    Span::styled("Created this session:", Theme::muted()),
+                    Theme::span("Created this session:"),
                     Theme::label_span(format!(" {}", card_created_count)),
                 ]));
                 if let Some(time) = card_last_save_attempt
@@ -169,7 +169,6 @@ async fn capture_cards(db: &DB, card_path: &Path) -> Result<()> {
                 }
 
                 let instructions = Paragraph::new(help_lines)
-                    .style(Theme::body())
                     .block(Theme::panel_with_line(Theme::section_header("Help")))
                     .wrap(Wrap { trim: true });
                 frame.render_widget(instructions, chunks[1]);

--- a/src/drill.rs
+++ b/src/drill.rs
@@ -186,12 +186,9 @@ async fn start_drill_session(db: &DB, cards: Vec<Card>) -> Result<()> {
                             state.cards.len()
                         )),
                         Theme::bullet(),
-                        Span::styled(
-                            format!("{} coming again", state.redo_cards.len()),
-                            Theme::muted(),
-                        ),
+                        Theme::span(format!("{} coming again", state.redo_cards.len())),
                         Theme::bullet(),
-                        Span::styled(card.file_path.display().to_string(), Theme::muted()),
+                        Theme::span(card.file_path.display().to_string()),
                     ]);
 
                     let content = format_card_text(&card, state.show_answer);
@@ -264,7 +261,7 @@ fn instructions_text(state: &DrillState<'_>) -> Vec<Line<'static>> {
     if state.show_answer {
         lines.push(Line::from(vec![
             Theme::key_chip("Space"),
-            Span::styled(" or ", Theme::muted()),
+            Theme::span(" or "),
             Theme::key_chip("Enter"),
             Span::styled(" Pass", Theme::success()),
             Theme::bullet(),
@@ -272,32 +269,32 @@ fn instructions_text(state: &DrillState<'_>) -> Vec<Line<'static>> {
             Span::styled(" Fail", Theme::danger()),
             Theme::bullet(),
             Theme::key_chip("Esc"),
-            Span::styled(" / ", Theme::muted()),
+            Theme::span(" / "),
             Theme::key_chip("Ctrl+C"),
-            Span::styled(" exit", Theme::muted()),
+            Theme::span(" exit"),
         ]));
     } else {
         let mut line = vec![
             Theme::key_chip("Space"),
-            Span::styled(" or ", Theme::muted()),
+            Theme::span(" or "),
             Theme::key_chip("Enter"),
-            Span::styled(" show answer", Theme::muted()),
+            Theme::span(" show answer"),
             Theme::bullet(),
             Theme::key_chip("Esc"),
-            Span::styled(" / ", Theme::muted()),
+            Theme::span(" / "),
             Theme::key_chip("Ctrl+C"),
-            Span::styled(" exit", Theme::muted()),
+            Theme::span(" exit"),
         ];
         if !state.current_medias.is_empty() {
             let num_media = state.current_medias.len();
             let plural = if num_media == 1 { "" } else { "s" };
             line.push(Theme::bullet());
-            line.push(Span::styled(
-                format!("{} media file{plural} found in card ", num_media),
-                Theme::muted(),
-            ));
+            line.push(Theme::span(format!(
+                "{} media file{plural} found in card ",
+                num_media
+            )));
             line.push(Theme::key_chip("O"));
-            line.push(Span::styled(" open", Theme::muted()));
+            line.push(Theme::span(" open"));
         }
         lines.push(Line::from(line));
     }
@@ -310,7 +307,7 @@ fn instructions_text(state: &DrillState<'_>) -> Vec<Line<'static>> {
             ReviewStatus::Fail => Theme::danger(),
         };
         lines.push(Line::from(vec![
-            Theme::muted_span("Last:"),
+            Theme::span("Last:"),
             Span::styled(action.print(), style),
         ]));
     }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -69,8 +69,8 @@ impl Theme {
         Span::styled(text.into(), Self::label())
     }
 
-    pub fn muted_span(text: impl Into<String>) -> Span<'static> {
-        Span::styled(text.into(), Self::muted())
+    pub fn span(text: impl Into<String>) -> Span<'static> {
+        Span::raw(text.into())
     }
 
     pub fn key_chip(text: impl Into<String>) -> Span<'static> {
@@ -84,7 +84,7 @@ impl Theme {
     }
 
     pub fn bullet() -> Span<'static> {
-        Span::styled(" • ", Self::muted())
+        Self::span(" • ")
     }
 
     pub fn section_header(text: impl Into<String>) -> Line<'static> {


### PR DESCRIPTION
Resolves #39 

I don't think the contrast of grays in terminal are good enough for text, so in this implementation, emphasis, text, and muted colors are all equal. 

I also added "key foreground" as foreground of the "key chip". There isn't a way to use the default background as a foreground so I just hardcoded it to the brightest white to ensure contrast.

Here is what they look like in Ghostty's default theme:
<img width="800" height="1048" alt="Screenshot from 2026-01-07 12-39-24" src="https://github.com/user-attachments/assets/d451dd47-10f0-4ee1-ba76-557356b90307" />

Here is what they look like in my custom light theme:
<img width="922" height="1048" alt="Screenshot from 2026-01-07 12-39-51" src="https://github.com/user-attachments/assets/352173ae-a03d-44c5-816f-0aa4bb906262" />

Should I remove some of the redundancy? I thought it might be useful to keep some of the constants in case in the future we want some user-configured theming, but I am not sure if that is within scope of the project.



