### PR TITLE
fix: control characters cause panic in openai headers

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,5 +1,6 @@
 use std::env;
 
+use crate::utils::strip_controls_and_escapes;
 use anyhow::{Context, Result, anyhow, bail};
 use async_openai::types::{
     ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
@@ -153,12 +154,15 @@ pub fn prompt_for_api_key(prompt: &str) -> Result<String> {
         reset = reset
     );
 
-    let input = read_password().context("Failed to read API key")?;
+    let mut input = read_password().context("Failed to read API key")?;
+    // Make input safe for use in a header
+    input = strip_controls_and_escapes(&input);
     Ok(input.trim().to_string())
 }
 
 pub fn store_api_key(api_key: &str) -> Result<()> {
     let trimmed = api_key.trim();
+
     if trimmed.is_empty() {
         bail!("Cannot store an empty API key");
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -493,6 +493,32 @@ pub async fn resolve_missing_clozes(cards: &mut [Card]) -> Result<()> {
 
     Ok(())
 }
+pub fn strip_controls_and_escapes(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            // ANSI escape sequence (ESC … letter)
+            '\x1b' => {
+                while let Some(&next) = chars.peek() {
+                    chars.next();
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+
+            // Drop all ASCII control characters
+            c if c.is_control() => {}
+
+            // Keep everything else (ASCII printable)
+            c => out.push(c),
+        }
+    }
+
+    out.trim().to_string()
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Bug: rpassowrd allows all characters including controls characters such as arrows keys, those however cause config.rs from openai verification to panic since the use of unwrap there.

Solution: This PR makes sure that keys obtain with rpassword are clear of said characters with a simple function `strip_controls_and_escapes` which i placed in utils.rs since it's more of a helper function.


