### PR TITLE
feat: add --shuffle flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,6 +2840,7 @@ dependencies = [
  "open",
  "proptest",
  "pulldown-cmark",
+ "rand 0.9.2",
  "ratatui",
  "regex",
  "reqwest 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ async-openai = {version="0.32.3", features = ["responses", "model"]}
 reqwest = { version = "0.13", features = ["json"] }
 open = "5"
 dialoguer = {version="0.12.0", features=["password"]}
+rand = "0.9"
 
 [dev-dependencies]
 criterion = { version = "0.8.1", features = ["async_tokio" ] }

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -7,6 +7,7 @@ Start a terminal drilling session for one or more files/directories (default: cu
 - `--card-limit <N>`: cap the number of cards reviewed this session.
 - `--new-card-limit <N>`: cap the number of unseen cards introduced.
 - `--rephrase`: rephrase basic questions via the LLM helper before the session starts.
+- `--shuffle`: randomize the order of cards in the session.
 
 Example: drill all the physics decks and a single chemistry deck, stopping after 20 cards.
 

--- a/src/commands/drill.rs
+++ b/src/commands/drill.rs
@@ -41,11 +41,17 @@ pub async fn run(
     card_limit: Option<usize>,
     new_card_limit: Option<usize>,
     rephrase_questions: bool,
+    shuffle: bool,
 ) -> Result<()> {
     let (hash_cards, _) = register_all_cards(db, paths).await?;
     let mut cards_due_today = db
         .due_today(&hash_cards, card_limit, new_card_limit)
         .await?;
+
+    if shuffle {
+        use rand::seq::SliceRandom;
+        cards_due_today.shuffle(&mut rand::rng());
+    }
 
     if cards_due_today.is_empty() {
         println!("All caught up—no cards due today.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ enum Command {
         /// Rephrase  card questions via the LLM helper before the session starts.
         #[arg(long = "rephrase", default_value_t = false)]
         rephrase_questions: bool,
+        /// Randomize the order of cards in the drill session
+        #[arg(long, default_value_t = false)]
+        shuffle: bool,
     },
     /// Re-index decks and show collection stats
     Check {
@@ -105,8 +108,9 @@ async fn run_cli() -> Result<()> {
             card_limit,
             new_card_limit,
             rephrase_questions,
+            shuffle,
         } => {
-            drill::run(&db, paths, card_limit, new_card_limit, rephrase_questions).await?;
+            drill::run(&db, paths, card_limit, new_card_limit, rephrase_questions, shuffle).await?;
         }
         Command::Check { paths, plain } => {
             let _ = check::run(&db, paths, plain).await?;


### PR DESCRIPTION
Feel free to ignore if this doesn't fit in with how you envision this tool, but when using SRS, I personally prefer for cards in my review batches to be shuffled (got this habit from wanikani.com, use this approach in a side project too). I've been loving using repeater, but also been missing this kind of behavior, so I implemented it.

Why I find this valuable: some types of cards become much easier if they follow quickly after other related cards. Shuffling allows related cards to be spread out a bit throughout a session, negating that advantage.