### PR TITLE
fix: Clarify version update prompt wording

### DIFF
--- a/src/check_version.rs
+++ b/src/check_version.rs
@@ -115,7 +115,7 @@ pub async fn prompt_for_new_version(db: &DB, notification: &VersionNotification)
 
     println!(
         "{}",
-        Palette::dim("Press any key to dismiss (I'll remind you again in a few days)")
+        Palette::dim("Press Enter to dismiss (I'll remind you again in a few days)")
     );
     let _ = io::stdout().flush();
 


### PR DESCRIPTION
## Summary

Update the version notification prompt to say `Press Enter to dismiss` instead of `Press any key to dismiss`.

## Why

The current implementation waits on `stdin.read_line()`, so the prompt is dismissed by pressing Enter, not by pressing any key. This change makes the message match the actual behavior.

## Changes

- replace `Press any key to dismiss (I'll remind you again in a few days)`
- with `Press Enter to dismiss (I'll remind you again in a few days)`

## Testing

- temporarily patched `check_version()` in `src/check_version.rs` to always return a fake newer version so the prompt would appear locally
- ran `cargo run -- check test_data/physics.md`
- confirmed the prompt now reads `Press Enter to dismiss (I'll remind you again in a few days)`
- reverted the temporary test patch and kept only the prompt wording change
