### PR TITLE
feat: render card images inline in terminals with graphics support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +242,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,11 +305,23 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -612,6 +643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +673,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -858,6 +901,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,13 +1164,13 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1224,7 +1279,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03bf4211cdbd68bb0fb8291e0ed825c13da0d1ac01b7c02dce3cee44a6138be"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "cubecl-common",
  "cubecl-ir",
@@ -1871,6 +1926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2067,12 @@ dependencies = [
  "snafu",
  "strum 0.27.2",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2420,6 +2490,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,7 +2556,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gpu-alloc-types",
 ]
 
@@ -2486,7 +2566,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2507,7 +2587,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2518,7 +2598,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2593,6 +2673,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2877,6 +2968,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfb5a63225620b59df34a235d1fb56ff7b766909c3212a8ff927511a22b181d"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +3024,34 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -3152,7 +3281,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -3174,8 +3303,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3212,11 +3347,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3338,7 +3473,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -3388,6 +3523,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0b3262dc837d2513fe2ef31ff8461352ef932dcca31ba0c0abe33547cf6b9b"
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "naga"
 version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,7 +3540,7 @@ checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
 dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "codespan-reporting",
  "half",
@@ -3443,7 +3588,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3633,7 +3778,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9bff0aa1d48904a1385ea2a8b97576fbdcbc9a3cfccd0d31fe978e1c4038c5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
@@ -3710,6 +3855,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +3877,40 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "bytemuck",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -3961,6 +4155,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,7 +4268,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -4101,7 +4308,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -4133,10 +4340,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quantette"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5d37e94c17b8870a5b936001d2845a6782a22ebdb1706c84294eca777f6729"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "palette",
+ "rand 0.10.1",
+ "rand_xoshiro",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -4208,6 +4445,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4305,6 +4548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
+dependencies = [
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4312,32 +4564,36 @@ checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "compact_str",
- "hashbrown 0.16.1",
- "indoc",
+ "critical-section",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum 0.27.2",
+ "palette",
+ "serde",
+ "strum 0.28.0",
  "thiserror 2.0.17",
  "unicode-segmentation",
  "unicode-truncate",
@@ -4346,9 +4602,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -4357,20 +4613,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui-macros"
-version = "0.7.0"
+name = "ratatui-image"
+version = "11.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.5",
+ "ratatui",
+ "rustix 0.38.44",
+ "self_cell",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
+name = "ratatui-termina"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -4378,18 +4662,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.10.0",
- "hashbrown 0.16.1",
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -4410,7 +4695,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4457,7 +4742,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4466,7 +4751,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4489,6 +4774,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4549,6 +4854,7 @@ dependencies = [
  "futures",
  "html-escape",
  "ignore",
+ "image",
  "once_cell",
  "open",
  "proptest",
@@ -4556,6 +4862,7 @@ dependencies = [
  "pulldown-cmark",
  "rand 0.10.1",
  "ratatui",
+ "ratatui-image",
  "regex",
  "reqwest",
  "serde",
@@ -4712,14 +5019,27 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4812,7 +5132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -4822,6 +5142,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "safe_arch"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "safetensors"
@@ -4882,7 +5211,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4898,6 +5227,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -5153,7 +5488,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5262,7 +5597,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -5305,7 +5640,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -5408,6 +5743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5425,6 +5769,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5461,6 +5817,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5486,7 +5853,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -5500,7 +5867,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -5528,7 +5895,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5558,6 +5925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5566,7 +5939,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5577,6 +5950,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.1",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5608,7 +5994,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -5621,7 +6007,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -5890,7 +6276,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -6175,6 +6561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6327,7 +6719,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -6381,6 +6773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6422,7 +6820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -6459,7 +6857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.15.5",
@@ -6489,7 +6887,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg_aliases",
  "document-features",
  "hashbrown 0.15.5",
@@ -6548,7 +6946,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.8.0",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block",
  "bytemuck",
  "cfg-if",
@@ -6569,7 +6967,7 @@ dependencies = [
  "naga",
  "ndk-sys",
  "objc",
- "ordered-float",
+ "ordered-float 4.6.0",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -6591,7 +6989,7 @@ version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytemuck",
  "js-sys",
  "log",
@@ -6607,6 +7005,16 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "wide"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -7188,7 +7596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "indexmap",
  "log",
  "serde",
@@ -7235,6 +7643,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xml-rs"
@@ -7437,4 +7854,19 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,14 @@ authors = ["Shaan Khosla <shaan.khosla@proton.me>"]
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-ratatui = "0.30.0"
+ratatui = "0.30.1"
+# `default-features = false` is deliberate: ratatui-image's default `chafa-dyn` feature links
+# system libchafa via pkg-config, which would break the cargo-dist release binaries. Never
+# enable `chafa-dyn`/`chafa-static`.
+ratatui-image = { version = "11", default-features = false, features = ["crossterm"] }
+# ratatui-image only asks `image` for the `png` codec; this list is what makes the other
+# formats in `media_kind_from_path` decodable, via cargo feature unification.
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
 crossterm = "0.29"
 anyhow = "1.0.102"
 sqlx = { version = "0.8", features = [ "runtime-tokio-rustls" , "sqlite", "chrono", "macros", "migrate"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,7 @@ authors = ["Shaan Khosla <shaan.khosla@proton.me>"]
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
 ratatui = "0.30.1"
-# `default-features = false` is deliberate: ratatui-image's default `chafa-dyn` feature links
-# system libchafa via pkg-config, which would break the cargo-dist release binaries. Never
-# enable `chafa-dyn`/`chafa-static`.
 ratatui-image = { version = "11", default-features = false, features = ["crossterm"] }
-# ratatui-image only asks `image` for the `png` codec; this list is what makes the other
-# formats in `media_kind_from_path` decodable, via cargo feature unification.
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
 crossterm = "0.29"
 anyhow = "1.0.102"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In practice, this means less flexibility but much less friction. You edit cards 
 ## Features
 
 - **Markdown-first decks**: write basic Q/A + cloze cards in plain `.md` alongside your notes.
-- **Media support**: open linked images/audio/video.
+- **Media support**: images drawn inline in terminals with graphics support (Kitty, Ghostty, iTerm2, WezTerm, foot, …); linked audio/video open in your OS viewer.
 - **Anki import**: import your existing Anki decks `.apkg` to Markdown.
 - **Stable card identity**: “meaning-only” hashing; formatting tweaks don’t reset progress.
 - **Optional LLM helper**: add an OpenAI key once to auto-suggest missing Cloze brackets and optionally rephrase basic questions (see the [docs](https://shaankhosla.github.io/repeater/llm-usage.html)).

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -10,6 +10,7 @@ Start a terminal drilling session for one or more files/directories (default: cu
 - `--shuffle`: randomize the order of cards in the session.
 - `--retention <FLOAT>`: target recall probability for FSRS scheduling (default: `0.9`, allowed range: `0.65`–`1.0`).
 - `--apple-notes` *(beta)*: source cards from Apple Notes instead of local Markdown files. macOS only — requires Full Disk Access for your terminal (System Settings > Privacy & Security > Full Disk Access). Conflicts with `[PATH ...]`.
+- `--inline-images <auto|off|always>`: draw card images directly in the terminal (default: `auto`). See [Media in Cards](./media-in-cards.md#inline-images).
 
 Example: drill all the physics decks and a single chemistry deck, stopping after 20 cards. This is just for extra practice, so let's lower the retention rate to `0.7`.
 
@@ -21,7 +22,8 @@ Key bindings inside the drill UI:
 
 - `Space`/`Enter`: reveal the answer or cloze.
 - `F`: mark as `Fail`, `Space`/`Enter`: mark as `Pass`.
-- `O`: open the first media file detected in the current card (images/audio/video). The file opens in your OS default viewer before the answer is revealed.
+- `O`: open a media file detected in the current card (images/audio/video) in your OS default viewer. Works on both the question and the answer side. When an image is being drawn inline, `O` opens that image; otherwise it opens the first attachment.
+- `I`: with an image drawn inline, toggle between sharing the card panel with the text and filling it.
 - `Esc` / `Ctrl+C`: exit the session.
 
 ### `repeater create <path/to/deck.md>`

--- a/docs/src/media-in-cards.md
+++ b/docs/src/media-in-cards.md
@@ -78,4 +78,4 @@ While drilling:
 
 If a file cannot be found you’ll see `File does not exist: …` in the terminal. Double-check the relative path from the deck file and ensure the media is synced locally.
 
-Multiple attachments can be detected; broader selection support is on the roadmap.
+Multiple attachments can be detected;

--- a/docs/src/media-in-cards.md
+++ b/docs/src/media-in-cards.md
@@ -1,6 +1,6 @@
 # Media in Cards
 
-`repeater` scans every rendered card for media references (images, audio, and video). When the drill UI detects at least one supported file, you can press `O` before revealing the answer to open the first attachment in your operating system’s default viewer/player. This keeps cards lightweight in the terminal while still letting you jump into richer references on demand.
+`repeater` scans every rendered card for media references (images, audio, and video). Images are drawn **directly in the terminal** when your terminal can display them; anything else — audio, video, or a terminal without graphics support — is one `O` keypress away from opening in your operating system’s default viewer/player.
 
 ## Supported formats
 
@@ -25,14 +25,57 @@ Relative paths are resolved from the directory that contains the deck file. For 
 
 will look for `notes/physics/figures/wave.png` and `notes/audio/tone.mp3`. Absolute paths work too, but keeping media alongside your decks makes them easier to sync and move.
 
+## Inline images
+
+In a terminal that supports a graphics protocol, an image on the side of the card you are
+looking at is drawn in the card panel: the question or answer text sits on top, the picture
+fills the space below it. Press `I` to give the picture the whole panel, and `I` again to go
+back. Because the image is tied to the visible side of the card, a picture in the answer only
+appears once you reveal it.
+
+Supported protocols and the terminals that use them:
+
+| Protocol | Terminals |
+| --- | --- |
+| Kitty graphics | Kitty (0.28+), Ghostty |
+| iTerm2 inline images | iTerm2, WezTerm, Rio |
+| Sixel | foot, xterm (`-ti 340`), mlterm |
+
+Terminals with no graphics protocol — Alacritty, Konsole, macOS Terminal.app, Windows
+conhost, Warp — are detected automatically and left alone: no image is drawn, and the footer
+hint plus `O` behave exactly as they always have. Nothing is silently degraded to a blurry
+approximation.
+
+Control this with `--inline-images`:
+
+- `auto` (default): draw images only where a real graphics protocol is available.
+- `off`: never draw inline; always rely on `O`.
+- `always`: also draw in terminals without a protocol, using coarse Unicode half-blocks.
+  Usable for photographs, poor for diagrams or anything with text in it.
+
+```sh
+repeater drill flashcards/anatomy/ --inline-images always
+```
+
+Notes and limits:
+
+- The format is detected from the file contents, not the extension, so a mislabeled file
+  still displays.
+- Animated GIFs show their first frame.
+- Very large images are downscaled before display, and files over 32 MB are skipped.
+- If an image cannot be displayed, the footer says why (`image not shown: …`) and the card
+  still drills normally — you can press `O` to open it externally.
+
 ## Opening media during a drill
 
 While drilling:
 
 - The footer shows “media file found” whenever the current card links to supported media.
-- Press `O` (uppercase or lowercase) before revealing the answer to open the first listed file.
+- Press `O` (uppercase or lowercase) to open it — on the question side or the answer side.
+  When an image is being drawn inline, `O` opens that image; otherwise it opens the first
+  attachment listed on the card.
 - The file launches via the OS default handler (`open` on macOS, `xdg-open` on Linux, `start` on Windows), so whatever app normally opens that file type will appear.
 
 If a file cannot be found you’ll see `File does not exist: …` in the terminal. Double-check the relative path from the deck file and ensure the media is synced locally.
 
-Multiple attachments can be detected, and the first one will open today; broader selection support is on the roadmap.
+Multiple attachments can be detected; broader selection support is on the roadmap.

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -30,7 +30,8 @@
    ```
 
    - `Space`/`Enter`: reveal the answer or cloze.
-   - `O`: open the first media file (image/audio/video) referenced in the current card before revealing the answer.
+   - `O`: open a media file (image/audio/video) referenced in the current card in your OS viewer.
+   - `I`: when an image is drawn inline, toggle it between sharing the panel and filling it.
    - `F`: mark as `Fail`, `Space`/`Enter`: mark as `Pass`.
    - `Esc` or `Ctrl+C`: end the session early (progress so far is saved).
 

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -2,7 +2,6 @@
 
 - [X] Import from Anki
 - [X] Show card images inline in terminals with graphics support
-- [ ] Extract images from Anki `.apkg` imports so imported decks keep their pictures
 - [ ] Allow scrolling to other cards in a collection while creating a new card
 - [ ] Edit an existing card while keeping the progress intact
 - [ ] Allow for a fuzzy search of existing cards

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -1,6 +1,8 @@
 # Roadmap
 
 - [X] Import from Anki
+- [X] Show card images inline in terminals with graphics support
+- [ ] Extract images from Anki `.apkg` imports so imported decks keep their pictures
 - [ ] Allow scrolling to other cards in a collection while creating a new card
 - [ ] Edit an existing card while keeping the progress intact
 - [ ] Allow for a fuzzy search of existing cards

--- a/src/commands/drill.rs
+++ b/src/commands/drill.rs
@@ -105,9 +105,6 @@ struct DrillState<'a> {
     show_answer: bool,
     last_action: Option<LastAction>,
     current_medias: Vec<Media>,
-    /// The rendered text and deck directory the current `current_medias` / `card_image`
-    /// were derived from. Used to re-resolve media only when what's on screen actually
-    /// changes, rather than on every frame.
     visible_key: Option<(String, Option<PathBuf>)>,
     card_image: CardImage,
     zoom_image: bool,
@@ -155,12 +152,6 @@ impl<'a> DrillState<'a> {
         }
     }
 
-    /// Resolve everything that depends on what's currently on screen, and return the card
-    /// plus its rendered text.
-    ///
-    /// Called once per loop iteration *before* drawing. Media extraction and image
-    /// decoding only happen when the visible text or deck directory changes, so the
-    /// expensive work runs once per card side rather than on every frame.
     fn sync_visible(&mut self, renderer: Option<&ImageRenderer>) -> (Card, String) {
         let card = self
             .current_card()
@@ -173,10 +164,6 @@ impl<'a> DrillState<'a> {
         };
         let base_dir = card.file_path.parent().map(|dir| dir.to_path_buf());
 
-        // Key on the rendered text itself rather than on the card hash: the hash is
-        // content-derived (so duplicate cards in different files collide) and the redo
-        // queue can rotate a different card into the same slot. The text plus the deck
-        // directory is exactly what media resolution depends on.
         let key = (content.clone(), base_dir.clone());
         if self.visible_key.as_ref() == Some(&key) {
             return (card, content);
@@ -196,8 +183,6 @@ impl<'a> DrillState<'a> {
         (card, content)
     }
 
-    /// The media `O` should open: the image being displayed when there is one, so the key
-    /// and the picture never disagree, otherwise the first attachment of any kind.
     fn media_to_open(&self) -> Option<&Media> {
         if self.card_image.is_ready() {
             self.current_medias.iter().find(|media| media.is_image())
@@ -291,10 +276,6 @@ async fn start_drill_session(
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen).context("failed to configure terminal")?;
 
-    // Probe for graphics support here, in the gap between entering the alternate screen and
-    // pushing the keyboard enhancement flags: the probe reads its reply from stdin, so it
-    // must run before anything else consumes input and before the kitty keyboard protocol
-    // changes how that reply arrives.
     let image_renderer = ImageRenderer::detect(inline_images);
 
     execute!(
@@ -343,9 +324,6 @@ async fn start_drill_session(
                 ai_preprocess_handle = None;
             }
 
-            // Everything that touches state happens before the draw closure, so drawing is
-            // pure rendering. Media extraction used to run inside the closure, re-parsing
-            // the card on every frame.
             let (card, content) = state.sync_visible(image_renderer.as_ref());
             let header_line = header_line(&state, &card);
             let body = render_markdown(&content);
@@ -381,9 +359,6 @@ async fn start_drill_session(
                 })
                 .context("failed to render frame")?;
 
-            // Encoding happens during rendering, so a protocol-level failure (a sixel
-            // encoder error, say) only becomes visible afterwards. Surface it in the footer
-            // instead of leaving an empty box.
             if let Some(protocol) = state.card_image.protocol_mut()
                 && let Some(Err(err)) = protocol.last_encoding_result()
             {
@@ -423,9 +398,6 @@ async fn start_drill_session(
                     KeyCode::Char('I') | KeyCode::Char('i')
                         if !ai_pending && state.card_image.is_ready() =>
                     {
-                        // No explicit repaint needed: every protocol anchors the picture to
-                        // buffer cells, so shrinking the image area lets ratatui's normal
-                        // diff overwrite the cells it used to occupy.
                         state.zoom_image = !state.zoom_image;
                     }
 
@@ -472,10 +444,6 @@ fn header_line(state: &DrillState<'_>, card: &Card) -> Line<'static> {
     Line::from(spans)
 }
 
-/// Footer chips for whatever media the current card side has.
-///
-/// Kept separate from the review keys because media is present in both the question and the
-/// answer state — an image on the back of a card is as worth opening as one on the front.
 fn media_hint(state: &DrillState<'_>, renderer: Option<&ImageRenderer>) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
     if state.current_medias.is_empty() {
@@ -550,8 +518,6 @@ fn instructions_text(
         ]));
     }
 
-    // On its own line: appended to the review keys it ran past the panel edge and the
-    // chips were silently truncated.
     if !state.current_medias.is_empty() {
         lines.push(Line::from(media_hint(state, renderer)));
     }

--- a/src/commands/drill.rs
+++ b/src/commands/drill.rs
@@ -12,7 +12,7 @@ use crate::palette::Palette;
 use crate::parser::register_all_cards;
 use crate::parser::render_markdown;
 use crate::parser::{Media, extract_media};
-use crate::tui::Theme;
+use crate::tui::{CardImage, ImageRenderer, InlineImages, Theme, image_widget, split_card_area};
 use crate::utils::pluralize;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -45,6 +45,7 @@ pub struct DrillOptions {
     pub shuffle: bool,
     pub retention: f32,
     pub apple_notes: bool,
+    pub inline_images: InlineImages,
 }
 
 pub async fn run(db: &DB, opts: DrillOptions) -> Result<()> {
@@ -80,6 +81,7 @@ pub async fn run(db: &DB, opts: DrillOptions) -> Result<()> {
         drill_preprocessor,
         opts.retention,
         opts.shuffle,
+        opts.inline_images,
     )
     .await?;
 
@@ -103,6 +105,12 @@ struct DrillState<'a> {
     show_answer: bool,
     last_action: Option<LastAction>,
     current_medias: Vec<Media>,
+    /// The rendered text and deck directory the current `current_medias` / `card_image`
+    /// were derived from. Used to re-resolve media only when what's on screen actually
+    /// changes, rather than on every frame.
+    visible_key: Option<(String, Option<PathBuf>)>,
+    card_image: CardImage,
+    zoom_image: bool,
     retention: f32,
     shuffle: bool,
 }
@@ -139,8 +147,62 @@ impl<'a> DrillState<'a> {
             show_answer: false,
             last_action: None,
             current_medias: Vec::new(),
+            visible_key: None,
+            card_image: CardImage::Absent,
+            zoom_image: false,
             retention,
             shuffle,
+        }
+    }
+
+    /// Resolve everything that depends on what's currently on screen, and return the card
+    /// plus its rendered text.
+    ///
+    /// Called once per loop iteration *before* drawing. Media extraction and image
+    /// decoding only happen when the visible text or deck directory changes, so the
+    /// expensive work runs once per card side rather than on every frame.
+    fn sync_visible(&mut self, renderer: Option<&ImageRenderer>) -> (Card, String) {
+        let card = self
+            .current_card()
+            .expect("card should exist while session is active");
+
+        let content = if self.current_ai_pending() {
+            "Enhancing this card with AI...\n\nPlease wait.".to_string()
+        } else {
+            format_card_text(&card, self.show_answer)
+        };
+        let base_dir = card.file_path.parent().map(|dir| dir.to_path_buf());
+
+        // Key on the rendered text itself rather than on the card hash: the hash is
+        // content-derived (so duplicate cards in different files collide) and the redo
+        // queue can rotate a different card into the same slot. The text plus the deck
+        // directory is exactly what media resolution depends on.
+        let key = (content.clone(), base_dir.clone());
+        if self.visible_key.as_ref() == Some(&key) {
+            return (card, content);
+        }
+
+        self.current_medias = extract_media(&content, base_dir.as_deref());
+        self.zoom_image = false;
+        self.card_image = match (renderer, self.current_medias.iter().find(|m| m.is_image())) {
+            (Some(renderer), Some(media)) => match renderer.load(media.path()) {
+                Ok(protocol) => CardImage::Ready(Box::new(protocol)),
+                Err(reason) => CardImage::Failed(reason),
+            },
+            _ => CardImage::Absent,
+        };
+        self.visible_key = Some(key);
+
+        (card, content)
+    }
+
+    /// The media `O` should open: the image being displayed when there is one, so the key
+    /// and the picture never disagree, otherwise the first attachment of any kind.
+    fn media_to_open(&self) -> Option<&Media> {
+        if self.card_image.is_ready() {
+            self.current_medias.iter().find(|media| media.is_image())
+        } else {
+            self.current_medias.first()
         }
     }
 
@@ -223,12 +285,20 @@ async fn start_drill_session(
     drill_preprocessor: DrillPreprocessor,
     retention: f32,
     shuffle: bool,
+    inline_images: InlineImages,
 ) -> Result<()> {
     enable_raw_mode().context("failed to enable raw mode")?;
     let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen).context("failed to configure terminal")?;
+
+    // Probe for graphics support here, in the gap between entering the alternate screen and
+    // pushing the keyboard enhancement flags: the probe reads its reply from stdin, so it
+    // must run before anything else consumes input and before the kitty keyboard protocol
+    // changes how that reply arrives.
+    let image_renderer = ImageRenderer::detect(inline_images);
+
     execute!(
         stdout,
-        EnterAlternateScreen,
         PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
                 | KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
@@ -273,11 +343,18 @@ async fn start_drill_session(
                 ai_preprocess_handle = None;
             }
 
+            // Everything that touches state happens before the draw closure, so drawing is
+            // pure rendering. Media extraction used to run inside the closure, re-parsing
+            // the card on every frame.
+            let (card, content) = state.sync_visible(image_renderer.as_ref());
+            let header_line = header_line(&state, &card);
+            let body = render_markdown(&content);
+            let instructions = instructions_text(&state, image_renderer.as_ref());
+            let zoom = state.zoom_image;
+
+            let card_image = &mut state.card_image;
             terminal
                 .draw(|frame| {
-                    let card = state
-                        .current_card()
-                        .expect("card should exist while session is active");
                     let area = frame.area();
                     frame.render_widget(Theme::backdrop(), area);
                     let chunks = Layout::default()
@@ -285,43 +362,33 @@ async fn start_drill_session(
                         .constraints([Constraint::Min(5), Constraint::Length(5)])
                         .split(area);
 
-                    let mut header_vec = vec![
-                        Theme::label_span(format!(
-                            "Card {}/{}",
-                            state.current_idx + 1,
-                            state.cards.len()
-                        )),
-                        Theme::bullet(),
-                        Theme::span(format!("{} coming again", state.redo_cards.len())),
-                        Theme::bullet(),
-                        Theme::span(card.file_path.display().to_string()),
-                    ];
-                    if card.ai_status == AIStatus::AiEnhanced {
-                        header_vec.push(Theme::bullet());
-                        header_vec.push(Theme::key_chip("AI enhanced"));
+                    let block = Theme::panel_with_line(header_line);
+                    let inner = block.inner(chunks[0]);
+                    frame.render_widget(block, chunks[0]);
+
+                    let (text_area, image_area) =
+                        split_card_area(inner, card_image.is_ready(), zoom);
+                    frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: false }), text_area);
+                    if let (Some(image_area), Some(protocol)) =
+                        (image_area, card_image.protocol_mut())
+                    {
+                        frame.render_stateful_widget(image_widget(), image_area, protocol);
                     }
-                    let header_line = Line::from(header_vec);
 
-                    let ai_pending = state.current_ai_pending();
-                    let content = if ai_pending {
-                        "Enhancing this card with AI...\n\nPlease wait.".to_string()
-                    } else {
-                        format_card_text(&card, state.show_answer)
-                    };
-                    let markdown = render_markdown(&content);
-                    state.current_medias = extract_media(&content, card.file_path.parent());
-
-                    let card_widget = Paragraph::new(markdown)
-                        .block(Theme::panel_with_line(header_line))
-                        .wrap(Wrap { trim: false });
-                    frame.render_widget(card_widget, chunks[0]);
-
-                    let instructions = instructions_text(&state);
                     let footer = Paragraph::new(instructions)
                         .block(Theme::panel_with_line(Theme::section_header("Controls")));
                     frame.render_widget(footer, chunks[1]);
                 })
                 .context("failed to render frame")?;
+
+            // Encoding happens during rendering, so a protocol-level failure (a sixel
+            // encoder error, say) only becomes visible afterwards. Surface it in the footer
+            // instead of leaving an empty box.
+            if let Some(protocol) = state.card_image.protocol_mut()
+                && let Some(Err(err)) = protocol.last_encoding_result()
+            {
+                state.card_image = CardImage::Failed(format!("{err}"));
+            }
 
             if event::poll(Duration::from_millis(16))?
                 && let Event::Key(key) = event::read()?
@@ -348,12 +415,18 @@ async fn start_drill_session(
                     KeyCode::Char('F') | KeyCode::Char('f') if state.show_answer && !ai_pending => {
                         state.handle_review(ReviewStatus::Fail).await?;
                     }
-                    KeyCode::Char('O') | KeyCode::Char('o')
-                        if !ai_pending
-                            && !state.show_answer
-                            && !state.current_medias.is_empty() =>
+                    KeyCode::Char('O') | KeyCode::Char('o') if !ai_pending => {
+                        if let Some(media) = state.media_to_open() {
+                            media.play()?;
+                        }
+                    }
+                    KeyCode::Char('I') | KeyCode::Char('i')
+                        if !ai_pending && state.card_image.is_ready() =>
                     {
-                        state.current_medias[0].play()?;
+                        // No explicit repaint needed: every protocol anchors the picture to
+                        // buffer cells, so shrinking the image area lets ratatui's normal
+                        // diff overwrite the cells it used to occupy.
+                        state.zoom_image = !state.zoom_image;
                     }
 
                     _ => {}
@@ -380,7 +453,64 @@ fn teardown_terminal(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>)
     Ok(())
 }
 
-fn instructions_text(state: &DrillState<'_>) -> Vec<Line<'static>> {
+fn header_line(state: &DrillState<'_>, card: &Card) -> Line<'static> {
+    let mut spans = vec![
+        Theme::label_span(format!(
+            "Card {}/{}",
+            state.current_idx + 1,
+            state.cards.len()
+        )),
+        Theme::bullet(),
+        Theme::span(format!("{} coming again", state.redo_cards.len())),
+        Theme::bullet(),
+        Theme::span(card.file_path.display().to_string()),
+    ];
+    if card.ai_status == AIStatus::AiEnhanced {
+        spans.push(Theme::bullet());
+        spans.push(Theme::key_chip("AI enhanced"));
+    }
+    Line::from(spans)
+}
+
+/// Footer chips for whatever media the current card side has.
+///
+/// Kept separate from the review keys because media is present in both the question and the
+/// answer state — an image on the back of a card is as worth opening as one on the front.
+fn media_hint(state: &DrillState<'_>, renderer: Option<&ImageRenderer>) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    if state.current_medias.is_empty() {
+        return spans;
+    }
+
+    spans.push(Theme::span(format!(
+        "{} found in card ",
+        pluralize("media file", state.current_medias.len())
+    )));
+    spans.push(Theme::key_chip("O"));
+    spans.push(Theme::span(" open"));
+
+    if state.card_image.is_ready() {
+        spans.push(Theme::bullet());
+        spans.push(Theme::key_chip("i"));
+        spans.push(Theme::span(if state.zoom_image { " fit" } else { " zoom" }));
+        if let Some(renderer) = renderer {
+            spans.push(Theme::span(format!(" ({})", renderer.protocol_name())));
+        }
+    } else if let Some(reason) = state.card_image.failure() {
+        spans.push(Theme::bullet());
+        spans.push(Span::styled(
+            format!("image not shown: {reason}"),
+            Theme::danger(),
+        ));
+    }
+
+    spans
+}
+
+fn instructions_text(
+    state: &DrillState<'_>,
+    renderer: Option<&ImageRenderer>,
+) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     if state.current_ai_pending() {
         lines.push(Line::from(vec![
@@ -407,7 +537,7 @@ fn instructions_text(state: &DrillState<'_>) -> Vec<Line<'static>> {
             Theme::span(" exit"),
         ]));
     } else {
-        let mut line = vec![
+        lines.push(Line::from(vec![
             Theme::key_chip("Space"),
             Theme::span(" or "),
             Theme::key_chip("Enter"),
@@ -417,18 +547,13 @@ fn instructions_text(state: &DrillState<'_>) -> Vec<Line<'static>> {
             Theme::span(" / "),
             Theme::key_chip("Ctrl+C"),
             Theme::span(" exit"),
-        ];
-        if !state.current_medias.is_empty() {
-            let num_media = state.current_medias.len();
-            line.push(Theme::bullet());
-            line.push(Theme::span(format!(
-                "{} found in card ",
-                pluralize("media file", num_media)
-            )));
-            line.push(Theme::key_chip("O"));
-            line.push(Theme::span(" open"));
-        }
-        lines.push(Line::from(line));
+        ]));
+    }
+
+    // On its own line: appended to the review keys it ran past the panel edge and the
+    // chips were silently truncated.
+    if !state.current_medias.is_empty() {
+        lines.push(Line::from(media_hint(state, renderer)));
     }
 
     if let Some(action) = &state.last_action
@@ -611,7 +736,7 @@ mod tests {
         let mut state = DrillState::new(&db, vec![basic_card("Q", "A")], 0.9, false);
         state.show_answer = true;
 
-        let lines = instructions_text(&state);
+        let lines = instructions_text(&state, None);
         let commands = flatten_line(&lines[0]);
 
         assert!(commands.contains("Pass"));
@@ -629,12 +754,190 @@ mod tests {
             last_reviewed_at: Instant::now(),
         });
 
-        let lines = instructions_text(&state);
+        let lines = instructions_text(&state, None);
         assert!(lines.len() >= 2);
 
         let last_line = flatten_line(lines.last().unwrap());
         assert!(last_line.contains("Last:"));
         assert!(last_line.contains("Fail"));
+    }
+
+    #[test]
+    fn sync_visible_resolves_media_once_per_card_side() {
+        let db = in_memory_db();
+        let card = basic_card(
+            "What is this? ![diagram](wave.png)",
+            "A wave [sound](t.mp3)",
+        );
+        let mut state = DrillState::new(&db, vec![card], 0.9, false);
+
+        let (_, question) = state.sync_visible(None);
+        assert!(question.contains("wave.png"));
+        assert_eq!(
+            state.current_medias.len(),
+            1,
+            "answer media not yet visible"
+        );
+
+        // Re-running on an unchanged card must be a no-op, not a re-parse: this is what
+        // keeps the work out of the ~60fps render path.
+        let key_before = state.visible_key.clone();
+        state.sync_visible(None);
+        assert_eq!(state.visible_key, key_before);
+
+        state.reveal_answer();
+        state.sync_visible(None);
+        assert_ne!(
+            state.visible_key, key_before,
+            "reveal must re-resolve media"
+        );
+        assert_eq!(
+            state.current_medias.len(),
+            2,
+            "answer-side media should now be found"
+        );
+    }
+
+    #[test]
+    fn media_hint_appears_in_both_question_and_answer_states() {
+        let db = in_memory_db();
+        let card = basic_card("Q ![diagram](wave.png)", "A");
+        let mut state = DrillState::new(&db, vec![card], 0.9, false);
+
+        state.sync_visible(None);
+        let question_footer = flatten_footer(&state, None);
+        assert!(
+            question_footer.contains("media file found in card"),
+            "{question_footer}"
+        );
+
+        state.reveal_answer();
+        state.sync_visible(None);
+        let answer_footer = flatten_footer(&state, None);
+        assert!(
+            answer_footer.contains("media file found in card"),
+            "media must stay openable after the answer is revealed: {answer_footer}"
+        );
+    }
+
+    #[test]
+    fn footer_omits_the_media_line_when_a_card_has_no_attachments() {
+        let db = in_memory_db();
+        let mut state = DrillState::new(&db, vec![basic_card("Q", "A")], 0.9, false);
+        state.sync_visible(None);
+
+        assert_eq!(
+            instructions_text(&state, None).len(),
+            1,
+            "a plain card should not gain an empty media line"
+        );
+    }
+
+    /// The media chips were once appended to the review-keys line, which overran the panel
+    /// and silently truncated them. Render the real footer widget and read the buffer back,
+    /// so a regression shows up as missing text rather than as a passing span assertion.
+    #[test]
+    fn footer_chips_survive_rendering_at_a_normal_terminal_width() {
+        use ratatui::{Terminal, backend::TestBackend, layout::Rect, widgets::Paragraph};
+
+        let db = in_memory_db();
+        let card = basic_card("Q ![d](test_data/synaptic_vessel.jpg)", "A");
+        let mut state = DrillState::new(&db, vec![card], 0.9, false);
+        let renderer = ImageRenderer::halfblocks();
+        state.sync_visible(Some(&renderer));
+        assert!(state.card_image.is_ready());
+
+        let instructions = instructions_text(&state, Some(&renderer));
+        let mut terminal = Terminal::new(TestBackend::new(100, 8)).unwrap();
+        terminal
+            .draw(|frame| {
+                // Exactly how the drill loop builds the footer — no wrapping, so an
+                // over-long line truncates at the panel edge instead of flowing.
+                let footer = Paragraph::new(instructions)
+                    .block(Theme::panel_with_line(Theme::section_header("Controls")));
+                frame.render_widget(footer, Rect::new(0, 0, 100, 5));
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let rendered: String = (0..5)
+            .flat_map(|y| (0..100).map(move |x| (x, y)))
+            .map(|(x, y)| buffer[(x, y)].symbol().to_string())
+            .collect();
+
+        for needle in ["show answer", "media file found in card", "O", "i", "zoom"] {
+            assert!(
+                rendered.contains(needle),
+                "footer lost {needle:?} when rendered at 100 columns:\n{rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn footer_reports_why_an_image_could_not_be_shown() {
+        let db = in_memory_db();
+        let card = basic_card("Q ![diagram](wave.png)", "A");
+        let mut state = DrillState::new(&db, vec![card], 0.9, false);
+        state.sync_visible(None);
+        state.card_image = CardImage::Failed("unreadable".to_string());
+
+        let footer = flatten_footer(&state, None);
+        assert!(footer.contains("image not shown: unreadable"), "{footer}");
+    }
+
+    #[test]
+    fn open_target_prefers_the_displayed_image_over_a_leading_audio_file() {
+        let db = in_memory_db();
+        // Audio first, image second, so the first media and the first *image* differ.
+        let card = basic_card(
+            "Q [clip](a.mp3) ![diagram](test_data/synaptic_vessel.jpg)",
+            "A",
+        );
+        let mut state = DrillState::new(&db, vec![card], 0.9, false);
+
+        state.sync_visible(None);
+        assert!(
+            state.media_to_open().unwrap().path().ends_with("a.mp3"),
+            "with no image displayed, O opens the first attachment"
+        );
+
+        // Now with a real decoded image on screen, `O` must open what is displayed.
+        let renderer = ImageRenderer::halfblocks();
+        state.visible_key = None;
+        state.sync_visible(Some(&renderer));
+        assert!(
+            state.card_image.is_ready(),
+            "fixture should decode via halfblocks"
+        );
+        assert!(
+            state
+                .media_to_open()
+                .unwrap()
+                .path()
+                .ends_with("synaptic_vessel.jpg"),
+            "O must open the picture the user can see"
+        );
+    }
+
+    #[test]
+    fn footer_offers_the_zoom_key_only_when_an_image_is_displayed() {
+        let db = in_memory_db();
+        let card = basic_card("Q ![d](test_data/synaptic_vessel.jpg)", "A");
+        let mut state = DrillState::new(&db, vec![card], 0.9, false);
+        let renderer = ImageRenderer::halfblocks();
+
+        state.sync_visible(None);
+        assert!(!flatten_footer(&state, None).contains("zoom"));
+
+        state.visible_key = None;
+        state.sync_visible(Some(&renderer));
+        let footer = flatten_footer(&state, Some(&renderer));
+        assert!(footer.contains("zoom"), "{footer}");
+        assert!(footer.contains("halfblocks"), "{footer}");
+
+        state.zoom_image = true;
+        let footer = flatten_footer(&state, Some(&renderer));
+        assert!(footer.contains("fit"), "{footer}");
     }
 
     #[tokio::test]
@@ -668,6 +971,15 @@ mod tests {
         let start = text.find('[').unwrap();
         let end = text[start..].find(']').unwrap() + start;
         text[start + 1..end].to_string()
+    }
+
+    /// The whole footer as one string, so tests do not depend on which line a chip sits on.
+    fn flatten_footer(state: &DrillState<'_>, renderer: Option<&ImageRenderer>) -> String {
+        instructions_text(state, renderer)
+            .iter()
+            .map(flatten_line)
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     fn flatten_line(line: &Line<'_>) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use repeater::commands::{
 };
 use repeater::crud::DB;
 use repeater::llm::client;
+use repeater::tui::InlineImages;
 use repeater::{import, llm, palette::Palette};
 
 #[derive(Parser, Debug)]
@@ -57,6 +58,10 @@ enum Command {
         /// Drill cards from Apple Notes instead of local files (macOS only).
         #[arg(long, default_value_t = false, conflicts_with = "paths")]
         apple_notes: bool,
+        /// Draw card images in the terminal. `auto` only does so where a graphics protocol
+        /// is available, `always` falls back to coarse half-blocks, `off` disables it.
+        #[arg(long, value_enum, default_value_t = InlineImages::Auto)]
+        inline_images: InlineImages,
     },
     /// Re-index decks and show collection stats
     Check {
@@ -124,6 +129,7 @@ async fn run_cli() -> Result<()> {
             shuffle,
             retention,
             apple_notes,
+            inline_images,
         } => {
             drill::run(&db, DrillOptions {
                 paths,
@@ -133,6 +139,7 @@ async fn run_cli() -> Result<()> {
                 shuffle,
                 retention,
                 apple_notes,
+                inline_images,
             }).await?;
         }
         Command::Check { paths, plain, apple_notes } => {

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -10,8 +10,20 @@ pub fn render_markdown(md: &str) -> Text<'static> {
     let mut list_stack: Vec<ListKind> = Vec::new();
     let mut pending_prefix: Option<String> = None;
     let mut in_code_block = false;
+    let mut in_image = false;
 
     for event in parser {
+        // Swallow everything inside an image, including its alt text. On a card whose
+        // picture *is* the question ("which department is this?"), rendering the alt text
+        // would hand over the answer.
+        if in_image {
+            if matches!(event, Event::End(TagEnd::Image)) {
+                in_image = false;
+                pop_style(&mut styles);
+            }
+            continue;
+        }
+
         match event {
             Event::Start(tag) => match tag {
                 Tag::Heading { level, .. } => {
@@ -28,6 +40,22 @@ pub fn render_markdown(md: &str) -> Text<'static> {
                 Tag::Link { .. } => push_style(&mut styles, |style| {
                     style.add_modifier(Modifier::UNDERLINED)
                 }),
+                // A content-free marker: it says "there is a picture here" without
+                // revealing anything about it. Terminals that can draw the picture render
+                // it separately; elsewhere this is the cue to press `O`. To caption an
+                // image, write the caption as ordinary text next to it.
+                Tag::Image { .. } => {
+                    in_image = true;
+                    push_style(&mut styles, |style| style.add_modifier(Modifier::DIM));
+                    push_text(
+                        "[image]",
+                        current_style(&styles),
+                        in_code_block,
+                        &mut lines,
+                        &mut current_line,
+                        &mut pending_prefix,
+                    );
+                }
                 Tag::CodeBlock(_) => {
                     flush_line(&mut lines, &mut current_line);
                     in_code_block = true;
@@ -678,12 +706,62 @@ mod tests {
     use super::latex_to_unicode_math;
     use super::render_markdown;
     use proptest::prelude::*;
+    use ratatui::style::Modifier;
     proptest! {
         #[test]
         fn test_markdown_render( content in "\\PC*") {
             render_markdown(&content);
         }
     }
+    #[test]
+    fn marks_images_without_leaking_their_alt_text() {
+        let text = render_markdown("![Position : Lozère](42.png) then plain");
+        let flattened = text
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.to_string())
+            .collect::<String>();
+
+        assert!(
+            flattened.contains("[image]"),
+            "image marker missing: {flattened}"
+        );
+        // The whole point: a card whose picture is the question must not print the answer.
+        assert!(
+            !flattened.contains("Lozère") && !flattened.contains("Position"),
+            "alt text leaked into the rendered card: {flattened}"
+        );
+        assert!(
+            !flattened.contains("42.png"),
+            "image path leaked into the rendered card: {flattened}"
+        );
+
+        // The marker dims itself; text after the image must not inherit that. An
+        // unbalanced push/pop here would dim the rest of the card.
+        let trailing = text.lines[0].spans.last().unwrap();
+        assert_eq!(trailing.content, " then plain");
+        assert!(!trailing.style.add_modifier.contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn image_alt_text_with_markup_is_fully_suppressed() {
+        // Alt text can contain nested inline markup; none of it may reach the card.
+        let text = render_markdown("![**bold** and `code` and _em_](secret.png) after");
+        let flattened = text
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.to_string())
+            .collect::<String>();
+
+        assert!(flattened.contains("[image]"), "{flattened}");
+        for leak in ["bold", "code", "em", "secret"] {
+            assert!(!flattened.contains(leak), "{leak:?} leaked: {flattened}");
+        }
+        assert!(flattened.contains(" after"), "{flattened}");
+    }
+
     #[test]
     fn renders_heading_and_paragraph() {
         let text = render_markdown("# Title\n\nBody");

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -13,9 +13,6 @@ pub fn render_markdown(md: &str) -> Text<'static> {
     let mut in_image = false;
 
     for event in parser {
-        // Swallow everything inside an image, including its alt text. On a card whose
-        // picture *is* the question ("which department is this?"), rendering the alt text
-        // would hand over the answer.
         if in_image {
             if matches!(event, Event::End(TagEnd::Image)) {
                 in_image = false;
@@ -40,10 +37,6 @@ pub fn render_markdown(md: &str) -> Text<'static> {
                 Tag::Link { .. } => push_style(&mut styles, |style| {
                     style.add_modifier(Modifier::UNDERLINED)
                 }),
-                // A content-free marker: it says "there is a picture here" without
-                // revealing anything about it. Terminals that can draw the picture render
-                // it separately; elsewhere this is the cue to press `O`. To caption an
-                // image, write the caption as ordinary text next to it.
                 Tag::Image { .. } => {
                     in_image = true;
                     push_style(&mut styles, |style| style.add_modifier(Modifier::DIM));

--- a/src/parser/media.rs
+++ b/src/parser/media.rs
@@ -19,6 +19,15 @@ pub struct Media {
 }
 
 impl Media {
+    /// Path to the file, already resolved against the deck's directory.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn is_image(&self) -> bool {
+        self.kind == MediaKind::Image
+    }
+
     pub fn play(&self) -> Result<()> {
         if !self.path.is_file() || !self.path.exists() {
             bail!("File does not exist: {}", self.path.display());
@@ -163,6 +172,20 @@ This is a normal link and should be ignored:
         ];
 
         assert_eq!(medias, expected);
+    }
+
+    #[test]
+    fn is_image_discriminates_by_kind() {
+        let contents = "![dog](media/dog.jpg)\n[audio](media/dog.mp3)\n[video](media/dog.mp4)";
+        let medias = extract_media(contents, None);
+
+        let images: Vec<&Path> = medias
+            .iter()
+            .filter(|media| media.is_image())
+            .map(|media| media.path())
+            .collect();
+
+        assert_eq!(images, vec![Path::new("media/dog.jpg")]);
     }
 
     #[test]

--- a/src/tui/inline_image.rs
+++ b/src/tui/inline_image.rs
@@ -1,0 +1,557 @@
+//! Inline image rendering for terminals that support a graphics protocol.
+//!
+//! Wraps `ratatui-image` so the rest of the codebase never depends on it directly. A
+//! terminal that cannot draw pixels simply gets no [`ImageRenderer`], and the drill UI
+//! falls back to the `O` key and the OS viewer exactly as it did before.
+//!
+//! Named `inline_image` rather than `image` on purpose: a module called `image` would
+//! shadow the `image` crate for every path inside it.
+
+use std::path::Path;
+
+use clap::ValueEnum;
+use image::Limits;
+use ratatui::layout::Rect;
+use ratatui_image::{
+    FilterType, Resize, StatefulImage,
+    picker::{Picker, ProtocolType},
+    protocol::StatefulProtocol,
+};
+
+/// Skip files this large rather than spend seconds decoding them mid-session.
+const MAX_IMAGE_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Refuse images with either dimension beyond this. A file-size cap alone does not bound
+/// the *decoded* size — a few hundred KB of PNG can expand to gigabytes — and
+/// `panic = "abort"` in the dist profile means a decoder blowup cannot be caught.
+const MAX_DECODED_EDGE: u32 = 16_384;
+
+/// Ceiling on what the decoder may allocate at once.
+const MAX_DECODE_ALLOC: u64 = 256 * 1024 * 1024;
+
+/// Downscale to this longest edge before handing the image to the protocol. Terminal
+/// cells are coarse enough that more pixels buy nothing, and it bounds the cost of the
+/// resize/encode that happens on the render thread when the area changes.
+const MAX_EDGE: u32 = 2048;
+
+/// Below this the card panel is too small to split usefully; show text only.
+const MIN_PANEL_HEIGHT: u16 = 8;
+const MIN_PANEL_WIDTH: u16 = 12;
+
+/// Rows always left to the question/answer text when an image shares the panel.
+const MIN_TEXT_ROWS: u16 = 3;
+
+/// Rows the text will never exceed when an image shares the panel. On a tall terminal a
+/// percentage split leaves the text area mostly empty whitespace while cramping the picture,
+/// so past this point the image takes everything else. Twelve rows is far more than any
+/// card's question or answer needs.
+const MAX_TEXT_ROWS: u16 = 12;
+
+/// Share of the card panel the image gets on shorter terminals, as a percentage of height.
+const IMAGE_HEIGHT_PERCENT: u16 = 45;
+
+/// When to draw card images directly in the terminal.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum InlineImages {
+    /// Render inline only when the terminal supports a real graphics protocol.
+    #[default]
+    Auto,
+    /// Never render inline; rely on `O` and the OS viewer.
+    Off,
+    /// Render inline even when that means chunky Unicode half-blocks.
+    Always,
+}
+
+/// The image state of the card currently on screen.
+pub enum CardImage {
+    /// No image on this side of the card, or inline rendering is unavailable.
+    Absent,
+    /// There is an image but it cannot be shown; holds the reason for the footer.
+    Failed(String),
+    /// Decoded and ready to draw.
+    Ready(Box<StatefulProtocol>),
+}
+
+impl CardImage {
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready(_))
+    }
+
+    /// Why the image could not be shown, if it could not.
+    pub fn failure(&self) -> Option<&str> {
+        match self {
+            Self::Failed(reason) => Some(reason),
+            _ => None,
+        }
+    }
+
+    pub fn protocol_mut(&mut self) -> Option<&mut StatefulProtocol> {
+        match self {
+            Self::Ready(protocol) => Some(protocol),
+            _ => None,
+        }
+    }
+}
+
+/// Decodes card images into a protocol the terminal can draw.
+pub struct ImageRenderer {
+    picker: Picker,
+}
+
+impl ImageRenderer {
+    /// Detect terminal graphics support, returning `None` when inline rendering is
+    /// unavailable or switched off.
+    ///
+    /// Must be called *after* entering the alternate screen and enabling raw mode, but
+    /// *before* the keyboard enhancement flags are pushed and before the event loop reads
+    /// its first key. The underlying query writes an escape sequence to stdout and reads
+    /// the reply from stdin; a reader that starts earlier would swallow that reply as
+    /// keystrokes, and the kitty keyboard protocol would change how it arrives.
+    pub fn detect(mode: InlineImages) -> Option<Self> {
+        match mode {
+            InlineImages::Off => None,
+            InlineImages::Auto => {
+                let mut picker = Picker::from_query_stdio().ok()?;
+                prefer_iterm2_over_kitty(&mut picker);
+                // Half-blocks turn diagrams and any text inside the image into mush, so
+                // under `Auto` we would rather show nothing and let the user press `O`.
+                if picker.protocol_type() == ProtocolType::Halfblocks {
+                    return None;
+                }
+                Some(Self { picker })
+            }
+            // `Always` exists precisely for terminals that fail the query, so fall back to
+            // half-blocks rather than giving up.
+            InlineImages::Always => {
+                let mut picker =
+                    Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks());
+                prefer_iterm2_over_kitty(&mut picker);
+                Some(Self { picker })
+            }
+        }
+    }
+
+    /// Name of the negotiated protocol, for the drill footer.
+    pub fn protocol_name(&self) -> &'static str {
+        match self.picker.protocol_type() {
+            ProtocolType::Halfblocks => "halfblocks",
+            ProtocolType::Sixel => "sixel",
+            ProtocolType::Kitty => "kitty",
+            ProtocolType::Iterm2 => "iterm2",
+        }
+    }
+
+    /// Decode an image once, ready to be drawn by [`image_widget`].
+    ///
+    /// The `Err` string is shown in the drill footer, so a bad path degrades to the `O`
+    /// fallback with an explanation instead of ending the session.
+    pub fn load(&self, path: &Path) -> Result<StatefulProtocol, String> {
+        let metadata = std::fs::metadata(path).map_err(|err| format!("cannot read: {err}"))?;
+        if !metadata.is_file() {
+            return Err("not a file".to_string());
+        }
+        if metadata.len() > MAX_IMAGE_BYTES {
+            return Err(format!("too large ({} MB)", metadata.len() / (1024 * 1024)));
+        }
+
+        // Guess the format from the contents rather than the extension, so a mislabeled
+        // file still renders and a non-image file fails cleanly.
+        let mut reader = image::ImageReader::open(path)
+            .map_err(|err| format!("cannot open: {err}"))?
+            .with_guessed_format()
+            .map_err(|err| format!("unreadable: {err}"))?;
+        reader.limits(decode_limits());
+        let decoded = reader.decode().map_err(|err| format!("{err}"))?;
+
+        // `thumbnail` is the fast downscale path; quality beyond this is invisible once
+        // the picture is mapped onto terminal cells.
+        let decoded = if decoded.width() > MAX_EDGE || decoded.height() > MAX_EDGE {
+            decoded.thumbnail(MAX_EDGE, MAX_EDGE)
+        } else {
+            decoded
+        };
+
+        Ok(self.picker.new_resize_protocol(decoded))
+    }
+
+    /// A renderer that needs no terminal, so tests elsewhere in the crate can exercise the
+    /// image paths without a tty. `from_query_stdio` must never be called in tests: CI has
+    /// no terminal to answer it.
+    #[cfg(test)]
+    pub(crate) fn halfblocks() -> Self {
+        Self {
+            picker: Picker::halfblocks(),
+        }
+    }
+}
+
+/// Does this environment look like iTerm2?
+///
+/// Deliberately keyed on `TERM_PROGRAM`/`LC_TERMINAL` rather than anything kitty-ish: real
+/// Kitty leaves `TERM_PROGRAM` unset (it sets `TERM=xterm-kitty` and `KITTY_WINDOW_ID`), and
+/// WezTerm reports `TERM_PROGRAM=WezTerm`, so neither can match here.
+fn looks_like_iterm2(var: impl Fn(&str) -> Option<String>) -> bool {
+    ["TERM_PROGRAM", "LC_TERMINAL"]
+        .iter()
+        .any(|key| var(key).is_some_and(|value| value.contains("iTerm")))
+}
+
+/// Work around iTerm2 answering the kitty graphics query without supporting kitty's
+/// placement mechanism.
+///
+/// `ratatui-image` treats the terminal's query response as authoritative, and iTerm2 3.5+
+/// replies that it speaks the kitty graphics protocol. But it does not implement kitty's
+/// Unicode-placeholder placement, which is how `ratatui-image` positions kitty images — so
+/// the picture gets transmitted and then silently never appears. iTerm2's own inline-image
+/// protocol works fine (it is what `imgcat` uses), so prefer it.
+///
+/// This is the same correction `ratatui-image` already applies to WezTerm and Konsole, which
+/// it blacklists from kitty for this exact reason; iTerm2 only started answering the query
+/// recently and has not been added upstream.
+fn prefer_iterm2_over_kitty(picker: &mut Picker) {
+    if picker.protocol_type() == ProtocolType::Kitty
+        && looks_like_iterm2(|key| std::env::var(key).ok())
+    {
+        picker.set_protocol_type(ProtocolType::Iterm2);
+    }
+}
+
+fn decode_limits() -> Limits {
+    // `Limits` is `#[non_exhaustive]`, so start from the default (which already caps
+    // allocation at 512 MiB) and tighten it.
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(MAX_DECODED_EDGE);
+    limits.max_image_height = Some(MAX_DECODED_EDGE);
+    limits.max_alloc = Some(MAX_DECODE_ALLOC);
+    limits
+}
+
+/// The widget used to draw a loaded image, letterboxed to fit its area.
+///
+/// `Resize::Fit(None)` would default to `FilterType::Nearest`, which aliases badly when a
+/// photo is squeezed into a few dozen terminal cells, so pick a real filter.
+pub fn image_widget() -> StatefulImage<StatefulProtocol> {
+    StatefulImage::default().resize(Resize::Fit(Some(FilterType::Triangle)))
+}
+
+/// Split a card panel into its text area and, when there is room, an image area.
+///
+/// Kept pure so the geometry is unit-testable without a terminal. Sizes the *image*
+/// deterministically and gives the remainder to the text, because the wrapped height of
+/// the text is not knowable here — `Text::height` counts logical lines, and the card
+/// paragraph wraps.
+pub fn split_card_area(inner: Rect, has_image: bool, zoom: bool) -> (Rect, Option<Rect>) {
+    if !has_image || inner.height < MIN_PANEL_HEIGHT || inner.width < MIN_PANEL_WIDTH {
+        return (inner, None);
+    }
+    if zoom {
+        // No text at all; a zero-height Paragraph renders as a no-op.
+        return (Rect { height: 0, ..inner }, Some(inner));
+    }
+
+    let image_height = (inner.height * IMAGE_HEIGHT_PERCENT / 100)
+        .max(inner.height.saturating_sub(MAX_TEXT_ROWS))
+        .clamp(4, inner.height.saturating_sub(MIN_TEXT_ROWS));
+    let text_height = inner.height - image_height;
+
+    let text = Rect {
+        height: text_height,
+        ..inner
+    };
+    let image = Rect {
+        y: inner.y + text_height,
+        height: image_height,
+        ..inner
+    };
+    (text, Some(image))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `StatefulProtocol` is not `Debug`, so `unwrap_err` is unavailable on `load`'s result.
+    fn load_err(renderer: &ImageRenderer, path: &str) -> String {
+        match renderer.load(Path::new(path)) {
+            Ok(_) => panic!("expected {path} to fail to load"),
+            Err(reason) => reason,
+        }
+    }
+
+    fn panel(width: u16, height: u16) -> Rect {
+        Rect {
+            x: 1,
+            y: 1,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn detect_off_never_queries_the_terminal() {
+        assert!(ImageRenderer::detect(InlineImages::Off).is_none());
+    }
+
+    #[test]
+    fn inline_images_defaults_to_auto() {
+        assert_eq!(InlineImages::default(), InlineImages::Auto);
+    }
+
+    #[test]
+    fn loads_a_real_image() {
+        let renderer = ImageRenderer::halfblocks();
+        let path = Path::new("test_data/synaptic_vessel.jpg");
+        assert!(path.is_file(), "fixture missing: {}", path.display());
+        assert!(renderer.load(path).is_ok());
+    }
+
+    /// End-to-end check of the pipeline that cannot otherwise be exercised without a
+    /// graphics terminal: decode a real file, hand it to the widget, and confirm the widget
+    /// actually painted into the buffer. Uses half-blocks because they land in ordinary
+    /// cells; the kitty/sixel/iTerm2 protocols emit escape sequences a test backend cannot
+    /// observe, but they share this code path.
+    #[test]
+    fn rendering_a_loaded_image_paints_the_buffer() {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let renderer = ImageRenderer::halfblocks();
+        let mut protocol = renderer
+            .load(Path::new("test_data/synaptic_vessel.jpg"))
+            .expect("fixture should decode");
+
+        let mut terminal = Terminal::new(TestBackend::new(40, 20)).unwrap();
+        let (_, image_area) = split_card_area(panel(38, 18), true, false);
+        let image_area = image_area.expect("image area expected");
+
+        terminal
+            .draw(|frame| frame.render_stateful_widget(image_widget(), image_area, &mut protocol))
+            .unwrap();
+
+        assert!(
+            protocol.last_encoding_result().is_none_or(|r| r.is_ok()),
+            "encoding the image failed"
+        );
+
+        let buffer = terminal.backend().buffer();
+        let painted = image_area
+            .rows()
+            .flat_map(|row| row.columns())
+            .filter(|cell| {
+                let cell = &buffer[*cell];
+                cell.symbol() != " " || cell.bg != ratatui::style::Color::Reset
+            })
+            .count();
+        assert!(painted > 0, "image widget painted nothing into its area");
+    }
+
+    #[test]
+    fn missing_file_reports_a_reason() {
+        let renderer = ImageRenderer::halfblocks();
+        let err = load_err(&renderer, "test_data/does_not_exist.png");
+        assert!(err.contains("cannot read"), "unexpected reason: {err}");
+    }
+
+    #[test]
+    fn directory_is_rejected() {
+        let renderer = ImageRenderer::halfblocks();
+        assert_eq!(load_err(&renderer, "test_data"), "not a file");
+    }
+
+    #[test]
+    fn non_image_bytes_are_rejected() {
+        // An existing Markdown fixture stands in for "not an image".
+        let renderer = ImageRenderer::halfblocks();
+        let err = load_err(&renderer, "test_data/physics.md");
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn oversized_file_is_rejected_before_decoding() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.png");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_IMAGE_BYTES + 1).unwrap();
+        drop(file);
+
+        let renderer = ImageRenderer::halfblocks();
+        let err = load_err(&renderer, path.to_str().unwrap());
+        assert!(err.contains("too large"), "unexpected reason: {err}");
+    }
+
+    #[test]
+    fn protocol_name_is_reported() {
+        assert_eq!(ImageRenderer::halfblocks().protocol_name(), "halfblocks");
+    }
+
+    #[test]
+    fn iterm2_is_recognised_from_either_env_var() {
+        let cases = [
+            (vec![("TERM_PROGRAM", "iTerm.app")], true),
+            (vec![("LC_TERMINAL", "iTerm2")], true),
+            (
+                vec![("TERM_PROGRAM", "iTerm.app"), ("LC_TERMINAL", "iTerm2")],
+                true,
+            ),
+            // Real Kitty leaves TERM_PROGRAM unset; must not be mistaken for iTerm2.
+            (
+                vec![("TERM", "xterm-kitty"), ("KITTY_WINDOW_ID", "1")],
+                false,
+            ),
+            // WezTerm also answers the kitty query but is not iTerm2.
+            (vec![("TERM_PROGRAM", "WezTerm")], false),
+            // Ghostty speaks real kitty graphics and must keep it.
+            (vec![("TERM_PROGRAM", "ghostty")], false),
+            (vec![("TERM_PROGRAM", "Apple_Terminal")], false),
+            (vec![], false),
+        ];
+        for (env, expected) in cases {
+            let lookup = |key: &str| {
+                env.iter()
+                    .find(|(k, _)| *k == key)
+                    .map(|(_, v)| (*v).to_string())
+            };
+            assert_eq!(
+                looks_like_iterm2(lookup),
+                expected,
+                "wrong verdict for {env:?}"
+            );
+        }
+    }
+
+    /// Guards the bug this works around: on iTerm2 the kitty protocol transmits the image
+    /// and then never displays it, because iTerm2 does not do kitty's Unicode-placeholder
+    /// placement. Assert the two protocols really do emit different, recognisable output.
+    #[test]
+    fn iterm2_protocol_emits_inline_image_sequences_not_kitty_placeholders() {
+        use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+
+        fn render(protocol: ProtocolType) -> String {
+            let mut picker = Picker::halfblocks();
+            picker.set_protocol_type(protocol);
+            let renderer = ImageRenderer { picker };
+            let mut proto = renderer
+                .load(Path::new("test_data/synaptic_vessel.jpg"))
+                .expect("fixture should decode");
+
+            let mut terminal = Terminal::new(TestBackend::new(40, 20)).unwrap();
+            terminal
+                .draw(|frame| {
+                    frame.render_stateful_widget(
+                        image_widget(),
+                        Rect::new(0, 0, 30, 12),
+                        &mut proto,
+                    )
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            (0..20)
+                .flat_map(|y| (0..40).map(move |x| (x, y)))
+                .map(|(x, y)| buffer[(x, y)].symbol().to_string())
+                .collect()
+        }
+
+        let kitty = render(ProtocolType::Kitty);
+        assert!(
+            kitty.contains('\u{10EEEE}'),
+            "kitty protocol should place via Unicode placeholders"
+        );
+
+        let iterm2 = render(ProtocolType::Iterm2);
+        assert!(
+            iterm2.contains("1337;File="),
+            "iterm2 protocol should emit its own inline-image sequence"
+        );
+        assert!(
+            !iterm2.contains('\u{10EEEE}'),
+            "iterm2 output must not rely on kitty placeholders"
+        );
+    }
+
+    #[test]
+    fn card_image_states() {
+        assert!(!CardImage::Absent.is_ready());
+        assert_eq!(CardImage::Absent.failure(), None);
+        let failed = CardImage::Failed("nope".to_string());
+        assert!(!failed.is_ready());
+        assert_eq!(failed.failure(), Some("nope"));
+    }
+
+    #[test]
+    fn no_image_takes_the_whole_panel() {
+        let inner = panel(40, 20);
+        let (text, image) = split_card_area(inner, false, false);
+        assert_eq!(text, inner);
+        assert!(image.is_none());
+    }
+
+    #[test]
+    fn split_reserves_text_and_image_without_overlap() {
+        let inner = panel(40, 20);
+        let (text, image) = split_card_area(inner, true, false);
+        let image = image.expect("image area expected");
+
+        assert!(text.height >= MIN_TEXT_ROWS);
+        assert_eq!(text.y, inner.y);
+        assert_eq!(image.y, text.y + text.height, "areas must be adjacent");
+        assert_eq!(text.height + image.height, inner.height, "must fill panel");
+    }
+
+    #[test]
+    fn tiny_panels_fall_back_to_text_only() {
+        for inner in [
+            panel(40, MIN_PANEL_HEIGHT - 1),
+            panel(MIN_PANEL_WIDTH - 1, 20),
+        ] {
+            let (text, image) = split_card_area(inner, true, false);
+            assert_eq!(text, inner);
+            assert!(image.is_none(), "panel {inner:?} is too small for an image");
+        }
+    }
+
+    #[test]
+    fn tall_panels_stop_wasting_rows_on_the_text() {
+        // A 60-row panel under a plain 45% split would leave 33 rows for three lines of
+        // text; the picture should get the space instead.
+        let (text, image) = split_card_area(panel(100, 60), true, false);
+        let image = image.expect("image area expected");
+        assert!(
+            text.height <= MAX_TEXT_ROWS,
+            "text kept {} rows on a tall panel",
+            text.height
+        );
+        assert!(image.height >= 60 - MAX_TEXT_ROWS);
+        assert_eq!(text.height + image.height, 60);
+    }
+
+    #[test]
+    fn short_panels_keep_the_percentage_split() {
+        let (text, image) = split_card_area(panel(100, 20), true, false);
+        let image = image.expect("image area expected");
+        assert_eq!(image.height, 9, "45% of 20 rows");
+        assert_eq!(text.height, 11);
+    }
+
+    #[test]
+    fn zoom_gives_the_whole_panel_to_the_image() {
+        let inner = panel(40, 20);
+        let (text, image) = split_card_area(inner, true, true);
+        assert_eq!(text.height, 0);
+        assert_eq!(image, Some(inner));
+    }
+
+    #[test]
+    fn split_never_panics_across_panel_sizes() {
+        for height in 0..60u16 {
+            for width in [0u16, 1, 11, 12, 80] {
+                for zoom in [false, true] {
+                    let inner = panel(width, height);
+                    let (text, image) = split_card_area(inner, true, zoom);
+                    if let Some(image) = image {
+                        assert!(text.height + image.height <= inner.height);
+                        assert!(image.height > 0);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,5 +1,7 @@
 pub mod editor;
+pub mod inline_image;
 pub mod theme;
 
 pub use editor::Editor;
+pub use inline_image::{CardImage, ImageRenderer, InlineImages, image_widget, split_card_area};
 pub use theme::Theme;


### PR DESCRIPTION
## What

Draw card images directly in the drill panel on terminals that support a graphics protocol, instead of only being able to shell out to an OS viewer with `O`.

Text sits on top, the picture fills the space below, and `I` gives the picture the whole panel. Only the visible side of the card is considered, so an image in the answer appears when the answer does.

## Why this shape

**Half-blocks are opt-in, not the default.** `ratatui-image` falls back to Unicode half-blocks where no graphics protocol exists. For diagrams, maps, or anything with text inside the image that is worse than nothing, so `auto` treats half-blocks as "no support" and leaves today's footer hint and `O` exactly as they are. `--inline-images always` opts in; `off` skips detection entirely.

| Protocol | Terminals |
| --- | --- |
| Kitty graphics | Kitty (0.28+), Ghostty |
| iTerm2 inline images | iTerm2, WezTerm, Rio |
| Sixel | foot, xterm (`-ti 340`), mlterm |

Alacritty, Konsole, macOS Terminal.app, Windows conhost and Warp are detected and left alone.

## Things worth a reviewer's attention

**No new system dependencies.** `ratatui-image`'s default feature set includes `chafa-dyn`, which links system `libchafa` via `pkg-config` — that would break the cargo-dist release binaries. It is pulled in with `default-features = false, features = ["crossterm"]`, and there is a comment in `Cargo.toml` so it does not get re-enabled by accident. `cargo build --release --locked` and `cargo tree` confirm no chafa and no `pkg-config` in the graph.

**`image` is declared directly on purpose.** `ratatui-image` only asks `image` for the `png` codec; feature unification via our explicit codec list is what makes the other formats already accepted by `media_kind_from_path` (jpg/jpeg/gif/webp/bmp) actually decodable.

**Decoding is bounded.** A file-size cap alone does not bound the *decoded* size — a few hundred KB of PNG can expand to gigabytes — and `panic = "abort"` in the dist profile means a decoder blowup cannot be caught. So there is an explicit `image::Limits` (max dimensions and max allocation) plus a downscale before encoding.

**Rendering an image can never end a session.** Missing file, unreadable data, oversize, unsupported format, or a protocol-level encode failure all become a short footer note and fall back to `O`.


## Testing

`cargo nextest run`, `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo build --release --locked` all pass. 120 tests, of which these are new:

- Protocol detection policy, and the iTerm2-vs-kitty correction across `TERM_PROGRAM`/`LC_TERMINAL` combinations including real Kitty, Ghostty, WezTerm and Terminal.app.
- That the kitty and iTerm2 protocols emit genuinely different, recognisable output — the regression that made this invisible on iTerm2 in the first place.
- Bounded decode: missing file, directory, non-image bytes, oversize.
- `split_card_area` geometry as a pure function, including degenerate panel sizes across a sweep (never panics, never overlaps, falls back to text-only when too small).
- End-to-end render into a `TestBackend`, asserting the widget actually paints.
- Footer chips surviving render at a normal terminal width — this one caught a real bug where the media chips were appended to the review-keys line, overran the panel and were silently truncated.
- Media resolving once per card side rather than per frame.

No `TestBackend` or snapshot harness existed before; tests stick to the repo's inline `#[cfg(test)] mod tests` convention and are all tty-free so the Windows CI leg passes.

Beyond the unit tests I drove the real binary through a sized pty that answers the terminal capability queries, and confirmed on a 202-card deck of French department maps: the kitty path, the iTerm2 path, the half-blocks path, the no-support fallback, `--inline-images off`, question-side and answer-side images, the `I` zoom toggle, and that the image data is transmitted once per (card, area) rather than re-encoded per frame.


---

I noticed #155 was closed as not planned, so this may not be something you want — very happy for it to be closed, or to split it up if only parts are interesting.

